### PR TITLE
add a --no-browser option

### DIFF
--- a/rodeo/cli.py
+++ b/rodeo/cli.py
@@ -1,13 +1,14 @@
 """rodeo
 
 Usage:
-  rodeo [--port=<int>] [<directory>]
+  rodeo [--port=<int>] [--no-browser] [<directory>]
   rodeo (-h | --help)
   rodeo --version
 
 Options:
   -h --help     Show this screen.
   --version     Show version.
+  --no-browser  Don't launch a web browser.
 
 Help:
 Rodeo is a data centric IDE for python. It leverages the IPython
@@ -35,10 +36,11 @@ def cmd():
     if arguments.get("<directory>"):
         active_dir = arguments.get("<directory>", ".")
         port = arguments.get("--port")
+        browser = False if arguments.get("--no-browser") else True
         if port and re.match("^[0-9]+$", port):
-            main(active_dir, int(port))
+            main(active_dir, port=int(port), browser=browser)
         else:
-            main(active_dir)
+            main(active_dir, browser=browser)
     else:
         sys.stdout.write(__doc__)
 

--- a/rodeo/rodeo.py
+++ b/rodeo/rodeo.py
@@ -60,7 +60,7 @@ def save_file():
         f.write(request.form['source'])
     return "OK"
 
-def main(directory, port=5000):
+def main(directory, port=5000, browser=True):
     global kernel
     global active_dir
     active_dir = os.path.realpath(directory)
@@ -79,7 +79,8 @@ def main(directory, port=5000):
 ''''''''''''''''''''''''''''''''''''''''''''''''''
 """.format(ART=art, PORT=port, DIR=active_dir)
     sys.stderr.write(display)
-    webbrowser.open("http://localhost:%d/" % port, new=2)
+    if browser:
+        webbrowser.open("http://localhost:%d/" % port, new=2)
     app.run(debug=False, port=port)
 
 if __name__=="__main__":


### PR DESCRIPTION
This is my proposed solution for #27. It creates similar functionality to iPython notebook's `--no-browser` option.