### PR TITLE
Avoid warning and update imports for IPython/Jupyter master

### DIFF
--- a/rodeo/kernel.py
+++ b/rodeo/kernel.py
@@ -1,4 +1,9 @@
-from IPython.kernel import BlockingKernelClient
+# start compatibility with IPython Jupyter 4.0+
+try:
+    from jupyter_client import BlockingKernelClient
+except ImportError:
+    from IPython.kernel import BlockingKernelClient
+
 # python3 sucks
 try:
     from Queue import Empty


### PR DESCRIPTION
I did not update the requirements, but that would prevent warning for people that have ipython master installed. 

