### PR TITLE
add option to make server externally visible

### DIFF
--- a/rodeo/cli.py
+++ b/rodeo/cli.py
@@ -1,7 +1,7 @@
 """rodeo
 
 Usage:
-  rodeo [--port=<int>] [--no-browser] [<directory>]
+  rodeo [--port=<int>] [--no-browser] [--host=<IP>] [<directory>]
   rodeo (-h | --help)
   rodeo --version
 
@@ -9,6 +9,7 @@ Options:
   -h --help     Show this screen.
   --version     Show version.
   --no-browser  Don't launch a web browser.
+  --host=<IP>   The IP to listen on.
 
 Help:
 Rodeo is a data centric IDE for python. It leverages the IPython
@@ -20,6 +21,7 @@ Examples:
 To run a rodeo server, just execute the `rodeo` command like so:
     $ rodeo . # basic usage
     $ rodeo . --port=4567 # run in this directory, but on port 4567
+    $ rodeo . --host=0.0.0.0 --no-browser # externally visible
     $ rodeo /path/to/a/folder # run in a different directory
     $ rodeo /path/to/a/folder --port=4567 # new directory, new port
 
@@ -37,10 +39,16 @@ def cmd():
         active_dir = arguments.get("<directory>", ".")
         port = arguments.get("--port")
         browser = False if arguments.get("--no-browser") else True
+        host = arguments.get("--host", None)
+        kwargs = {"browser": browser}
+
         if port and re.match("^[0-9]+$", port):
-            main(active_dir, port=int(port), browser=browser)
-        else:
-            main(active_dir, browser=browser)
+            kwargs["port"] = int(port)
+        if host and re.match("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", host):
+            kwargs["host"] = host
+
+        main(active_dir, **kwargs)
+
     else:
         sys.stdout.write(__doc__)
 

--- a/rodeo/rodeo.py
+++ b/rodeo/rodeo.py
@@ -60,10 +60,13 @@ def save_file():
         f.write(request.form['source'])
     return "OK"
 
-def main(directory, port=5000, browser=True):
+def main(directory, **kwargs):
     global kernel
     global active_dir
     active_dir = os.path.realpath(directory)
+    port = kwargs.get("port", 5000)
+    browser = kwargs.get("browser", True)
+    host = kwargs.get("host", None)
     # get rid of plots
     for f in os.listdir(os.path.join(__dirname, "static", "plots")):
         f = os.path.join(__dirname, "static", "plots", f)
@@ -81,7 +84,7 @@ def main(directory, port=5000, browser=True):
     sys.stderr.write(display)
     if browser:
         webbrowser.open("http://localhost:%d/" % port, new=2)
-    app.run(debug=False, port=port)
+    app.run(debug=False, host=host, port=port)
 
 if __name__=="__main__":
     if len(sys.argv)==1:


### PR DESCRIPTION
The simplest way to solve #31 would be to change `app.run(debug=False, port=port)` to `app.run(debug=False, port=port, host='0.0.0.0')`, but that could be problematic for security.

Instead, this PR adds a `--host` option to the `rodeo` command. The following would start the Rodeo IDE on a remote machine and allow access on port 8888:

    rodeo --host=0.0.0.0 --port=8888 --no-browser .

I've tested the changes on an ubuntu EC2 box.