### PR TITLE
Fixed setup.py for python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import io
 from setuptools import find_packages, setup
 
 def extract_version():
@@ -41,7 +42,7 @@ setup(
     },
     description="an ide for data analysis in python",
     # run pandoc --from=markdown --to=rst --output=README.rst README.md
-    long_description=open("README.rst", encoding='utf8').read(),
+    long_description=io.open("README.rst", encoding='utf8').read(),
     install_requires=[
         "ipython>=3.0.0",
         "Flask>=0.10.1",


### PR DESCRIPTION
open doesn't have an encoding flag in 2.7