### PR TITLE
Spark on Rodeo

### DIFF
--- a/rodeo/cli.py
+++ b/rodeo/cli.py
@@ -1,7 +1,7 @@
 """rodeo
 
 Usage:
-  rodeo [--verbose] [--no-browser] [--host=<IP>] [--port=<int>] [<directory>]
+  rodeo [--verbose] [--no-browser] [--host=<IP>] [--port=<int>] [--pyspark] [<directory>]
   rodeo (-h | --help)
   rodeo --version
 
@@ -12,6 +12,7 @@ Options:
   --port=<int>  Port you want to run the server on.
   --no-browser  Don't launch a web browser.
   --host=<IP>   The IP to listen on.
+  --pyspark     Use the pyspark kernel
 
 Help:
 Rodeo is a data centric IDE for python. It leverages the IPython
@@ -35,6 +36,7 @@ from .__init__ import __version__
 from docopt import docopt
 import sys
 import re
+import os
 
 def cmd():
     arguments = docopt(__doc__, version="rodeo %s" % __version__)
@@ -57,7 +59,14 @@ def cmd():
 
         verbose = arguments.get("--verbose", False)
 
-        main(active_dir, port=port, host=host, browser=browser, verbose=verbose)
+        pyspark = arguments.get("--pyspark", False)
+        if pyspark:
+            SPARK_HOME = os.environ.get("SPARK_HOME", None)
+            assert SPARK_HOME, "You must set SPARK_HOME to use the pyspark kernel"
+            assert os.path.isdir(SPARK_HOME), "SPARK_HOME must be a valid directory"
+
+        main(active_dir, port=port, host=host, browser=browser,
+             verbose=verbose, pyspark=pyspark)
 
     else:
         sys.stdout.write(__doc__)

--- a/rodeo/kernel.py
+++ b/rodeo/kernel.py
@@ -71,14 +71,13 @@ class Kernel(object):
         # right now we're spawning a child process for IPython. we can 
         # probably work directly with the IPython kernel API, but the docs
         # don't really explain how to do it.
+        log_file = None
         if pyspark:
             os.environ["IPYTHON_OPTS"] = "kernel -f %s" % config
             pyspark = os.path.join(os.environ.get("SPARK_HOME"), "bin/pyspark")
             spark_log = os.environ.get("SPARK_LOG", None)
             if spark_log:
                 log_file = open(spark_log, "w")
-            else:
-                log_file = None
             spark_opts = os.environ.get("SPARK_OPTS", "")
             args = [pyspark] + spark_opts.split()  # $SPARK_HOME/bin/pyspark <SPARK_OPTS>
             p = subprocess.Popen(args, stdout=log_file, stderr=log_file)

--- a/rodeo/rodeo.py
+++ b/rodeo/rodeo.py
@@ -97,7 +97,7 @@ def upload_data():
     else:
         return "No file specified"
 
-def main(directory, port=5000, host=None, browser=True, verbose=False):
+def main(directory, port=5000, host=None, browser=True, verbose=False, pyspark=False):
     global kernel
     global active_dir
     active_dir = os.path.realpath(directory)
@@ -111,7 +111,7 @@ def main(directory, port=5000, host=None, browser=True, verbose=False):
         logging.basicConfig(format='[%(levelname)s]: %(message)s', level=logging.WARNING)
 
 
-    kernel = Kernel(active_dir)
+    kernel = Kernel(active_dir, pyspark)
     art = open(os.path.join(__dirname, "rodeo-ascii.txt"), 'r').read()
     display = """
 {ART}


### PR DESCRIPTION
## Spark on Rodeo

Rodeo is a perfect fit for how our data science team uses Apache Spark. We currently launch IPython notebooks to interact with Spark on a YARN cluster for prototyping all kinds of data science jobs that need to scale. The problem is we end up with a bunch of `*.ipynb` files that are barely human-readable in our git repositories. Furthermore, these files need to be translated into `*.py` scripts when we are ready to deploy them. Instead, Rodeo would allow us to prototype in `*.py` files that are easy to code review and easy to push to production. I think this could turn out to be a common use-case for Rodeo, so I hope you'll consider merging my humble pull request.

### Quickstart

    export SPARK_HOME=~/spark
    export SPARK_OPTS="--master local[*]"
    rodeo --pyspark .

### Spark config

One irritating thing about using the Pyspark kernel instead of the vanilla IPython kernel is that sending output to `subprocess.PIPE` causes intensive Spark jobs to hang. Instead, including the `--pyspark` flag will send the kernel logs to stdout by default (clobbering the nice RODEO graphic). It's also possible to send Spark logs to a file:

    export SPARK_LOG=~/spark.out
    rodeo --pyspark .
    
Typically, we would send Spark output to some file and then monitor the progress of calls to Spark by watching the file:

    tail -f ~/spark.out
    
The nice thing about using environment variables for Spark on Rodeo is that they can all be set in a config file without mucking up all the function calls in Rodeo. We will probably create a `spark-config.sh` file with the following:

    export SPARK_HOME=/path/to/spark
    export SPARK_OPTS="--master yarn-client --num-executors 25 --driver-memory 8g --executor-memory 4g"
    export SPARK_LOG=/path/to/spark.out
 
 Then to launch Rodeo, we will run:
 
     source spark-config.sh
     rodeo --no-browser --port 8888 --host 0.0.0.0 --pyspark .
     
### Spark on Rodeo example

The Pyspark kernel comes with a `SparkContext` object, `sc` and a `SQLContext` object (or `HiveContext` if Spark has been compiled with Hive support) `sqlCtx` already set. Here is the canonical word count example:

![screen shot 2015-04-26 at 9 09 01 pm](https://cloud.githubusercontent.com/assets/4348863/7340725/9e815f9a-ec59-11e4-9335-6941a8dd2fd0.png)
