### PR TITLE
 ISSUE #73  fixed for crash in win7

### DIFF
--- a/rodeo/kernel.py
+++ b/rodeo/kernel.py
@@ -79,7 +79,8 @@ class Kernel(object):
         atexit.register(p.terminate)
 
         def remove_config():
-            os.remove(config)
+            if (os.exist(config)):
+                os.remove(config)
         atexit.register(remove_config)
 
         # i found that if i tried to connect to the kernel immediately, it wasn't


### PR DESCRIPTION
In windows7 , python 2.7

crash occured while generating "kernel-UUID.json" file 

It removes current kernel.json file without checking existence of the file

therefore I added some code for checking existence of the file.