### PR TITLE
ISSUE #73 fixed bug in win7

### DIFF
--- a/rodeo/kernel.py
+++ b/rodeo/kernel.py
@@ -79,12 +79,14 @@ class Kernel(object):
         atexit.register(p.terminate)
 
         def remove_config():
-            os.remove(config)
+            if (os.path.isfile(config)):
+                os.remove(config)
         atexit.register(remove_config)
 
         # i found that if i tried to connect to the kernel immediately, it wasn't
         # up and running. 1.5 seconds was arbitrarily chosen (but seems to work)
-        time.sleep(1.5)
+        while not os.path.isfile(config):
+            time.sleep(1.5)
         # fire up the kernel with the appropriate config
         self.client = BlockingKernelClient(connection_file=config)
         self.client.load_connection_file()


### PR DESCRIPTION
ISSUE #73

In windows7 , python 2.7

crash occured while generating "kernel-UUID.json" file

It removes current kernel.json file without checking existence of the file

therefore I added some code for checking existence of the file.