### PR TITLE
ipython-kernel based autocomplete

### DIFF
--- a/rodeo/kernel.py
+++ b/rodeo/kernel.py
@@ -16,29 +16,9 @@ import uuid
 import time
 import os
 import sys
+import json
 
 __dirname = os.path.dirname(os.path.abspath(__file__))
-
-
-# explanation of this in `complete` function
-autocomplete_patch = """
-import jedi
-
-def __autocomplete(code):
-    script = jedi.Interpreter(code, [globals()])
-    results = []
-    for completion in script.completions():
-        result = {
-            "text": completion.name,
-            "dtype": "---"
-        }
-        if code.endswith("."):
-            result["dtype"] = "function"
-        else:
-            result["dtype"] = "session variable" # type(globals().get(code)).__name__
-        results.append(result)
-    print(json.dumps(results))
-"""
 
 vars_patch = """
 import json
@@ -68,7 +48,7 @@ class Kernel(object):
     def __init__(self, active_dir, pyspark):
         # kernel config is stored in a dot file with the active directory
         config = os.path.join(active_dir, ".kernel-%s.json" % str(uuid.uuid4()))
-        # right now we're spawning a child process for IPython. we can 
+        # right now we're spawning a child process for IPython. we can
         # probably work directly with the IPython kernel API, but the docs
         # don't really explain how to do it.
         log_file = None
@@ -84,7 +64,7 @@ class Kernel(object):
         else:
             args = [sys.executable, '-m', 'IPython', 'kernel', '-f', config]
             p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        
+
         # when __this__ process exits, we're going to remove the ipython config
         # file and kill the ipython subprocess
         atexit.register(p.terminate)
@@ -110,26 +90,25 @@ class Kernel(object):
         self.client.start_channels()
         # load our monkeypatches...
         self.client.execute("%matplotlib inline")
-        self.client.execute(autocomplete_patch)
         self.client.execute(vars_patch)
 
     def _run_code(self, code, timeout=0.1):
         # this function executes some code and waits for it to completely finish
-        # before returning. i don't think that this is neccessarily the best 
-        # way to do this, but the IPython documentation isn't very helpful for 
+        # before returning. i don't think that this is neccessarily the best
+        # way to do this, but the IPython documentation isn't very helpful for
         # this particular topic.
-        # 
+        #
         # 1) execute code and grab the ID for that execution thread
-        # 2) look for messages coming from the "iopub" channel (this is just a 
+        # 2) look for messages coming from the "iopub" channel (this is just a
         #    stream of output)
-        # 3) when we get a message that is one of the following, save relevant 
+        # 3) when we get a message that is one of the following, save relevant
         # data to `data`:
         #       - execute_result - content from repr
         #       - stream - content from stdout
         #       - error - ansii encoded stacktrace
-        # the final piece is that we check for when the message indicates that 
-        # the kernel is idle and the message's parent is the original execution 
-        # ID (msg_id) that's associated with our executing code. if this is the 
+        # the final piece is that we check for when the message indicates that
+        # the kernel is idle and the message's parent is the original execution
+        # ID (msg_id) that's associated with our executing code. if this is the
         # case, we'll return the data and the msg_id and exit
         msg_id = self.client.execute(code)
         output = { "msg_id": msg_id, "output": None, "image": None, "error": None }
@@ -155,12 +134,56 @@ class Kernel(object):
     def execute(self, code):
         return self._run_code(code)
 
-    def complete(self, code):
-        # i couldn't figure out how to get the autocomplete working with the 
-        # ipython kernel (i couldn't get a completion_reply from the iopub), so 
-        # we're using jedi to do the autocompletion. the __autocomplete is 
-        # defined in `autocomplete_patch` above.
-        return self.execute("__autocomplete('%s')" % code)
-    
+    def complete(self, code, timeout=0.1):
+        # Call ipython kernel complete, wait for response with the correct msg_id,
+        # and construct appropriate UI payload.
+        # See below for an example response from ipython kernel completion for 'el'
+        #
+        # {
+        # 'parent_header':
+        #     {u'username': u'ubuntu', u'version': u'5.0', u'msg_type': u'complete_request',
+        #     u'msg_id': u'5222d158-ada8-474e-88d8-8907eb7cc74c', u'session': u'cda4a03d-a8a1-4e6c-acd0-de62d169772e',
+        #     u'date': datetime.datetime(2015, 5, 7, 15, 25, 8, 796886)},
+        # 'msg_type': u'complete_reply',
+        # 'msg_id': u'a3a957d6-5865-4c6f-a0b2-9aa8da718b0d',
+        # 'content':
+        #     {u'matches': [u'elif', u'else'], u'status': u'ok', u'cursor_start': 0, u'cursor_end': 2, u'metadata': {}},
+        # 'header':
+        #     {u'username': u'ubuntu', u'version': u'5.0', u'msg_type': u'complete_reply',
+        #     u'msg_id': u'a3a957d6-5865-4c6f-a0b2-9aa8da718b0d', u'session': u'f1491112-7234-4782-8601-b4fb2697a2f6',
+        #     u'date': datetime.datetime(2015, 5, 7, 15, 25, 8, 803470)},
+        # 'buffers': [],
+        # 'metadata': {}
+        # }
+        #
+        msg_id = self.client.complete(code)
+        output = { "msg_id": msg_id, "output": None, "image": None, "error": None }
+        while True:
+            try:
+                reply = self.client.get_shell_msg(timeout=timeout)
+            except Empty:
+                continue
+
+            if "matches" in reply['content'] and reply['msg_type']=="complete_reply" and reply['parent_header']['msg_id']==msg_id:
+                results = [{"text":"", "dtype":"---"}] #for when we have no completion results
+                #do what was being done in the jedi case
+                for completion in reply['content']['matches']:
+                    result = {
+                        "text": completion,
+                        "dtype": "---"
+                    }
+                    if code.endswith("."):
+                        result["dtype"] = "function"
+                    else:
+                        result["dtype"] = "session variable" # type(globals().get(code)).__name__
+                        results.append(result)
+                jsonresults = json.dumps(results)
+                output['output'] = jsonresults
+                return output
+            #else:
+                #Don't know what to do with the rest.
+                #I've observed parent_header msg_types: kernel_info_request, execute_request
+                #Just discard for now
+
     def get_dataframes(self):
         return self.execute("__get_variables()")


### PR DESCRIPTION
Run autocomplete on the ipython kernel instead of jedi.

Calls ipython client.complete with python text and receives responses on client.get_shell_msg

Kernel api details from - https://ipython.org/ipython-doc/dev/api/generated/IPython.kernel.client.html