### PR TITLE
hot-module-replacement working

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eslint = require('eslint/lib/cli'),
+const  eslint = require('eslint/lib/cli'),
   globby = require('globby'),
   gulp = require('gulp'),
   concat = require('gulp-concat'),
@@ -10,7 +10,7 @@ const eslint = require('eslint/lib/cli'),
   KarmaServer = karma.Server,
   path = require('path'),
   sourcemaps = require('gulp-sourcemaps'),
-  webpack = require('webpack-stream');
+  webpackStream = require('webpack-stream');
 
 gulp.task('eslint-browser', function () {
   return globby([
@@ -125,15 +125,22 @@ gulp.task('themes', ['fonts'], function () {
     .pipe(gulp.dest('dist/themes'));
 });
 
-gulp.task('webpack', function () {
+gulp.task('jsx', function () {
   return gulp.src([
     'src/browser/jsx/entry/*.js'
-  ]).pipe(webpack(require('./webpack.config.js')))
+  ]).pipe(webpackStream(require('./webpack.config.js')))
+    .pipe(gulp.dest('dist'));
+});
+
+gulp.task('hot', function () {
+  return gulp.src([
+    'src/browser/jsx/entry/*.js'
+  ]).pipe(webpackStream(require('./webpack.dev.config.js')))
     .pipe(gulp.dest('dist'));
 });
 
 gulp.task('test', ['eslint-node', 'eslint-browser', 'karma-browser', 'karma-node']);
-gulp.task('build', ['themes', 'external', 'ace', 'webpack', 'html']);
+gulp.task('build', ['themes', 'external', 'ace', 'jsx', 'html']);
 gulp.task('run', []);
 gulp.task('watch', function () {
   gulp.watch(['public/js/**/*.js'], ['js']);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "rodeo-web": "./bin/rodeo-web"
   },
   "devDependencies": {
+    "ansi-html": "0.0.5",
     "babel-core": "^6.7.7",
     "babel-loader": "^6.2.4",
     "babel-plugin-lodash": "^3.0.0",
@@ -54,6 +55,7 @@
     "gulp-util": "^3.0.7",
     "gulp-wrap": "^0.11.0",
     "handlebars": "^4.0.5",
+    "html-entities": "^1.2.0",
     "karma": "^0.13.22",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-chai": "^0.1.0",
@@ -72,6 +74,7 @@
     "minimist": "^1.1.1",
     "mkdirp": "^0.5.0",
     "mocha": "^2.4.5",
+    "react-hot-loader": "^1.3.0",
     "react-tools": "^0.13.3",
     "redux-devtools": "^3.2.0",
     "redux-thunk": "^2.0.1",
@@ -79,16 +82,21 @@
     "rimraf": "^2.4.3",
     "sandboxed-module": "^2.0.2",
     "sinon": "^1.17.3",
+    "strip-ansi": "^3.0.1",
     "style-loader": "^0.13.1",
     "svgo": "^0.6.6",
     "svgo-loader": "^1.1.0",
     "uglify-js": "^2.4.24",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.0",
+    "webpack-dev-middleware": "^1.6.1",
+    "webpack-dev-server": "^1.14.1",
+    "webpack-hot-middleware": "^2.10.0",
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
     "async": "^1.4.2",
+    "babel-register": "^6.8.0",
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.0",
     "bootstrap": "^3.3.6",
@@ -122,7 +130,8 @@
     "yargs": "^4.6.0"
   },
   "scripts": {
-    "start": "electron .",
+    "start": "electron . -r babel-register",
+    "hot-server": "node -r babel-register server.js",
     "test": "./node_modules/.bin/gulp test",
     "build": "electron-compile --target ./cache src/ static/ --verbose && node scripts/build.js"
   },

--- a/server.js
+++ b/server.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import webpack from 'webpack';
+import webpackDevMiddleware from 'webpack-dev-middleware';
+import webpackHotMiddleware from 'webpack-hot-middleware';
+
+import config from './webpack.dev.config.js';
+
+const app = express();
+const compiler = webpack(config);
+const PORT = 3001;
+
+app.use(webpackDevMiddleware(compiler, {
+  publicPath: config.output.publicPath,
+  stats: {
+    colors: true
+  }
+}));
+
+app.use(webpackHotMiddleware(compiler));
+
+app.listen(PORT, 'localhost', err => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  console.log(`Listening at http://localhost:${PORT}`);
+});

--- a/src/browser/jsx/components/file-viewer/file-viewer.jsx
+++ b/src/browser/jsx/components/file-viewer/file-viewer.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {connect} from 'react-redux';
 import React from 'react';
 import FileListItem from './file-list-item.jsx';
-import {selectViewedFile, getViewedFiles, openViewedFile, goToParentDirectory} from './file-viewer.actions';
+import fileViewerActions from './file-viewer.actions';
 import './file-viewer.less';
 
 function mapStateToProps(state) {
@@ -11,10 +11,10 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    onRefresh: (filePath) => dispatch(getViewedFiles(filePath)),
-    onClick: (file) => dispatch(selectViewedFile(file)),
-    onOpenFile: (file) => dispatch(openViewedFile(file)),
-    onGoToParentDirectory: (file) => dispatch(goToParentDirectory(file))
+    onRefresh: (filePath) => dispatch(fileViewerActions.getViewedFiles(filePath)),
+    onClick: (file) => dispatch(fileViewerActions.selectViewedFile(file)),
+    onOpenFile: (file) => dispatch(fileViewerActions.openViewedFile(file)),
+    onGoToParentDirectory: (file) => dispatch(fileViewerActions.goToParentDirectory(file))
   };
 }
 

--- a/src/browser/jsx/containers/studio-layout/studio-layout.css
+++ b/src/browser/jsx/containers/studio-layout/studio-layout.css
@@ -41,7 +41,7 @@ main {
 }
 
 .icon-overflowing:first-child {
-  margin-left: 5px;
+  margin-left: 15px;
 }
 
 .icon-overflowing span {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,13 +1,21 @@
 'use strict';
 
-const path = require('path');
+const path = require('path'),
+  webpack = require('webpack');
 
 module.exports = {
   context: path.join(__dirname, 'src/browser/jsx'),
+  debug: true,
   devtool: 'source-map',
   entry: {
-    startup: ['./entry/startup'],
-    main: ['./entry/main']
+    startup: [
+      'webpack-hot-middleware/client?path=http://localhost:3001/__webpack_hmr',
+      './entry/startup'
+    ],
+    main: [
+      'webpack-hot-middleware/client?path=http://localhost:3001/__webpack_hmr',
+      './entry/main'
+    ]
   },
   externals: {
     'ascii-table': 'AsciiTable',
@@ -40,9 +48,21 @@ module.exports = {
     __filename: true,
     __dirname: true
   },
+  plugins: [
+    new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin(),
+    new webpack.DefinePlugin({
+      __DEV__: true,
+      'process.env': {
+        NODE_ENV: JSON.stringify('development')
+      }
+    })
+  ],
   output: {
     filename: '[name].js',
-    path: path.join(__dirname, 'dist')
+    path: path.join(__dirname, 'dist'),
+    publicPath: 'http://localhost:3001/dist/'
   },
   stats: {
     colors: true


### PR DESCRIPTION
New Development Feature
- allow hot module replacement, so we can edit the css and see the changes in real-time

To build and run project normally:
```bash
npm install
gulp build
npm start
```

To build and run the project with this feature, build the webpack modules slightly differently:
```bash
npm install
gulp build
gulp hot
npm start
```
and in another tab, run the server that will serve up the changed bundles
```
npm run hot-server
```
