### PR TITLE
sane image sizes in plot-viewer

### DIFF
--- a/src/browser/jsx/components/plot-preview/plot-preview.css
+++ b/src/browser/jsx/components/plot-preview/plot-preview.css
@@ -24,6 +24,11 @@
   align-content: center;
   align-items: center;
   justify-content: center;
+  max-width: 80%;
+}
+
+.plot-viewer img {
+  max-width: 100%;
 }
 
 .plot-viewer nav {

--- a/src/browser/jsx/containers/editor-tab-group/editor-tab-group.reducer.js
+++ b/src/browser/jsx/containers/editor-tab-group/editor-tab-group.reducer.js
@@ -150,7 +150,6 @@ function shiftFocus(state, action, move) {
 }
 
 /**
- *
  * @param {object} state
  * @param {string} propertyName
  * @param {*} value

--- a/src/browser/jsx/containers/file-viewer/file-viewer.jsx
+++ b/src/browser/jsx/containers/file-viewer/file-viewer.jsx
@@ -18,6 +18,10 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
+function isDotFile(filename) {
+  return _.startsWith(_.last(filename.split(/[\/\\]/)), '.');
+}
+
 /**
  * @class FileViewer
  * @extends ReactComponent
@@ -31,26 +35,34 @@ export default connect(mapStateToProps, mapDispatchToProps)(React.createClass({
     id: React.PropTypes.string,
     onRefresh: React.PropTypes.func,
     onSelect: React.PropTypes.func,
-    path: React.PropTypes.string.isRequired
+    path: React.PropTypes.string.isRequired,
+    showDotFiles: React.PropTypes.string
   },
   getDefaultProps: function () {
     return {
       onRefresh: _.noop,
       onSelect: _.noop,
       path: '~',
-      filter: ''
+      filter: '',
+      showDotFiles: false
     };
   },
   componentDidMount: function () {
     const props = this.props;
 
-    console.log('file-viewer', props.path, props);
-
     this.props.onRefresh(props.path);
   },
   render: function () {
-    const props = this.props,
-      files = _.filter(props.files, item => !props.filter || item.filename.indexOf(props.filter) > -1);
+    const props = this.props;
+    let files = props.files;
+
+    if (props.filter) {
+      files = _.filter(files, item => item.filename.indexOf(props.filter) > -1);
+    }
+
+    if (!props.showDotFiles) {
+      files = _.filter(files, item => !isDotFile(item.filename));
+    }
 
     return (
       <FileList onGoToParent={props.onGoToParentDirectory}>

--- a/src/browser/jsx/containers/file-viewer/file-viewer.reducer.js
+++ b/src/browser/jsx/containers/file-viewer/file-viewer.reducer.js
@@ -12,7 +12,8 @@ function getDefault() {
   return {
     id: cid(),
     path: store.get('workingDirectory') || homedir || '~',
-    files: []
+    files: [],
+    showDotFiles: store.get('displayDotFiles') || false
   };
 }
 
@@ -38,7 +39,34 @@ function selectFile(state, action) {
   return state;
 }
 
+/**
+ * @param {object} state
+ * @param {string} propertyName
+ * @param {*} value
+ * @returns {object}
+ */
+function changeProperty(state, propertyName, value) {
+  state = _.cloneDeep(state);
+
+  console.log('file-viewer:before', state, propertyName, value);
+
+  _.set(state, propertyName, value);
+
+  console.log('file-viewer:after', state, propertyName, value);
+
+  return state;
+}
+
+function changePreference(state, action) {
+  switch (action.key) {
+    case 'showDotFiles': return changeProperty(state, 'showDotFiles', action.value);
+    default: return state;
+  }
+}
+
+
 export default mapReducers({
   LIST_VIEWED_FILES: setFileList,
-  SELECT_VIEWED_FILE: selectFile
+  SELECT_VIEWED_FILE: selectFile,
+  CHANGE_PREFERENCE: changePreference
 }, initialState);

--- a/src/browser/jsx/containers/preferences-viewer/preferences.yml
+++ b/src/browser/jsx/containers/preferences-viewer/preferences.yml
@@ -65,10 +65,10 @@
     label: File Viewer
     items:
       -
-        key: filesDisplayDotFiles
+        key: showDotFiles
         label: Display Dot Files
         type: checkbox
-        defaultValue: true
+        defaultValue: false
   -
     label: Plots
     items:

--- a/src/browser/jsx/containers/terminal/terminal.actions.js
+++ b/src/browser/jsx/containers/terminal/terminal.actions.js
@@ -5,6 +5,7 @@ import store from '../../services/store';
 import cid from '../../services/cid';
 import AsciiToHtml from 'ansi-to-html';
 import {errorCaught} from '../../actions/application';
+import plotViewerActions from '../plot-viewer/plot-viewer.actions';
 const convertor = new AsciiToHtml(),
   inputBuffer = [];
 
@@ -117,25 +118,41 @@ function appendIFrame(jqConsole, data) {
 }
 
 /**
+ * @param {function} dispatch
  * @param {object} jqConsole
  * @param {object} data
  */
-function appendPNG(jqConsole, data) {
-  const src = data['image/png'];
+function appendPNG(dispatch, jqConsole, data) {
+  const src = data['image/png'],
+    id = cid();
 
-  jqConsole.Append(`<img src="${src}">`);
-  jqConsole.Write('\n');
+  jqConsole.Append(`<img id=${id} src="${src}">`);
+
+  _.defer(function () {
+    document.querySelector('#' + id)
+      .addEventListener('click', function () {
+        dispatch(plotViewerActions.focusNewestPlot());
+      });
+  });
 }
 
 /**
+ * @param {function} dispatch
  * @param {object} jqConsole
  * @param {object} data
  */
-function appendSVG(jqConsole, data) {
-  const src = data['image/svg'];
+function appendSVG(dispatch, jqConsole, data) {
+  const src = data['image/svg'],
+    id = cid();
 
-  jqConsole.Append(`<img src="${src}">`);
-  jqConsole.Write('\n');
+  jqConsole.Append(`<img id=${id} src="${src}">`);
+
+  _.defer(function () {
+    document.querySelector('#' + id)
+      .addEventListener('click', function () {
+        dispatch(plotViewerActions.focusNewestPlot());
+      });
+  });
 }
 
 /**
@@ -154,10 +171,10 @@ function addDisplayData(data) {
         appendIFrame(jqConsole, data);
       }
     } else if (data['image/png']) {
-      appendPNG(jqConsole, data);
+      appendPNG(dispatch, jqConsole, data);
       // do nothing at the moment
     } else if (data['image/svg']) {
-      appendSVG(jqConsole, data);
+      appendSVG(dispatch, jqConsole, data);
     } else {
       console.warn('addDisplayData', 'unknown data type', data);
     }

--- a/src/browser/jsx/containers/terminal/terminal.css
+++ b/src/browser/jsx/containers/terminal/terminal.css
@@ -1,0 +1,11 @@
+.jqconsole img, iframe {
+  max-width: 100px;
+  margin: 15px;
+  cursor: pointer;
+}
+
+.jqconsole-prompt,
+.jqconsole-old-prompt,
+.jqconsole-output {
+  display: block;
+}

--- a/src/browser/jsx/containers/terminal/terminal.jsx
+++ b/src/browser/jsx/containers/terminal/terminal.jsx
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './lib/jqconsole.js';
+import './terminal.css';
 
 let message = `
 IPython -- An enhanced Interactive Python.
@@ -101,8 +102,7 @@ export default React.createClass({
     jqConsole.RegisterShortcut('e', function () {
       jqConsole.MoveToEnd();
     });
-
-
+    
     props.onStart(jqConsole);
   },
   render: function () {

--- a/test/mocks/jupyter_examples/test.py
+++ b/test/mocks/jupyter_examples/test.py
@@ -1,1 +1,0 @@
-from ggplot import *

--- a/test/mocks/jupyter_examples/test2.py
+++ b/test/mocks/jupyter_examples/test2.py
@@ -1,1 +1,0 @@
-from ggplot import *

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -25,7 +25,8 @@ module.exports = {
     'ascii-table': 'AsciiTable',
     jquery: 'jQuery',
     templates: 'templates',
-    ace: 'ace'
+    ace: 'ace',
+    ipc: 'ipc'
   },
   module: {
     // preLoaders: [


### PR DESCRIPTION

New Features:
- Preferences: show dot files is hooked up

- Console: images are small, and line up with each other.

<img width="388" alt="screen shot 2016-06-08 at 5 01 31 pm" src="https://cloud.githubusercontent.com/assets/4154804/15911191/9ba016ec-2d9c-11e6-950d-6facd629eec4.png">

- Plots: main image does not grow more than container size.

<img width="617" alt="screen shot 2016-06-08 at 4 53 22 pm" src="https://cloud.githubusercontent.com/assets/4154804/15911207/ab79d90e-2d9c-11e6-8a7b-3ef7250e9e67.png">