### PR TITLE
Starting copy

### DIFF
--- a/src/browser/jsx/components/setup/python-test-input.jsx
+++ b/src/browser/jsx/components/setup/python-test-input.jsx
@@ -21,6 +21,9 @@ export default React.createClass({
     this.props.onTest(e.target.value);
     e.preventDefault();
   },
+  handleSubmit: function (e) {
+    e.preventDefault();
+  },
   render: function () {
     const props = this.props,
       className = [
@@ -38,7 +41,7 @@ export default React.createClass({
     }
 
     return (
-      <form className="form python-test-input">
+      <form className="form python-test-input" onSubmit={this.handleSubmit}>
         <div className="form-group">
           {label}
           <input className={'form-control ' + props.status} id="python-test-input" onChange={this.handleChange} value={props.cmd} />

--- a/src/browser/jsx/components/setup/setup.css
+++ b/src/browser/jsx/components/setup/setup.css
@@ -27,6 +27,10 @@ li {
   margin: 20px;
 }
 
+.marked li {
+  margin: 0;
+}
+
 ul.horizontal {
   display: block;
 }
@@ -59,13 +63,13 @@ ul.horizontal li {
 .setup-content {
   position: relative;
   height: 100%;
-  width: 50%;
+  width: 80%;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
 }
 
-.setup .marked {
+.setup .faded {
   color: #888888;
 }
 

--- a/src/browser/jsx/components/setup/setup.jsx
+++ b/src/browser/jsx/components/setup/setup.jsx
@@ -47,10 +47,11 @@ export default React.createClass({
         content = (
           <div className="setup-content">
             <p>{'Where is python?'}</p>
-            <Marked>{'Examples:\n\n' + props.examples}</Marked>
+            <Marked className="faded">{props.examples}</Marked>
             <ul className="horizontal">
               <PythonTestInput onTest={props.onTest} {...props.pythonTest} />
               <SetupListItem onClick={_.partial(props.onAsk, 'MANUAL_OR_MISSING')}>{'Back'}</SetupListItem>
+              <SetupListItem disabled={props.pythonTest.status === 'valid'} onClick={_.partial(props.onAsk, 'MISSING')}>{'Still not working'}</SetupListItem>
               <SetupListItem
                 disabled={props.pythonTest.status !== 'valid'}
                 onClick={_.partial(props.onSaveTest, props.pythonTest.cmd)}
@@ -61,7 +62,7 @@ export default React.createClass({
       } else {
         content = (
           <div className="setup-content">
-            <p>{'Looks like we can\'t find python.'}</p>
+            <Marked>{props.rejectedInstructions}</Marked>
             <ul>
               <SetupListItem onClick={_.partial(props.onAsk, 'MANUAL')}>{'Let me set the path manually'}</SetupListItem>
               <SetupListItem onClick={_.partial(props.onAsk, 'MISSING')}>{'I don\'t have python installed'}</SetupListItem>

--- a/src/browser/jsx/containers/setup-viewer/rejected-instructions.md
+++ b/src/browser/jsx/containers/setup-viewer/rejected-instructions.md
@@ -1,0 +1,1 @@
+Looks like we can't find a usable python.

--- a/src/browser/jsx/containers/setup-viewer/setup-viewer.jsx
+++ b/src/browser/jsx/containers/setup-viewer/setup-viewer.jsx
@@ -5,6 +5,7 @@ import setupActions from './setup-viewer.actions';
 import unixExamples from './unix-examples.md';
 import win32Examples from './win32-examples.md';
 import installInstructions from './install-instructions.md';
+import rejectedInstructions from './rejected-instructions.md';
 
 function mapStateToProps(state) {
   return state.setup;
@@ -45,7 +46,8 @@ export default connect(mapStateToProps, mapDispatchToProps)(React.createClass({
   getDefaultProps: function () {
     return {
       examples: process.platform === 'win32' ?  win32Examples : unixExamples,
-      installInstructions
+      installInstructions,
+      rejectedInstructions
     };
   },
   render: function () {

--- a/src/browser/jsx/containers/setup-viewer/unix-examples.md
+++ b/src/browser/jsx/containers/setup-viewer/unix-examples.md
@@ -1,4 +1,6 @@
-~/Anaconda/Anaconda3/bin/python
-~/.pyenv/versions/3.4.3/bin/python
-~/user/venv/bin/python2.7
-~/anaconda2/envs/adap_int/bin/python
+Rodeo is more than a Python IDE.  It needs a Jupyter/IPython kernel.
+
+Examples:
+- ~/.pyenv/versions/3.4.3/bin/python
+- ~/user/venv/bin/python2.7
+- ~/anaconda2/envs/adap_int/bin/python

--- a/src/browser/jsx/containers/setup-viewer/win32-examples.md
+++ b/src/browser/jsx/containers/setup-viewer/win32-examples.md
@@ -1,9 +1,3 @@
-%PYTHONHOME%\bin\python
-C:\Anaconda\bin\python
-C:\Anaconda2\python.exe
-C:\Python\python.exe
-C:\Python27\python.exe
-%HOME%\Anaconda2\python.exe
-%HOME%\Anaconda 3\python.exe
-%HOME%\Anaconda2\python.exe
-%HOME%\Anaconda332\envs\python27\python.exe
+Examples:
+- C:\Anaconda2\python.exe
+- %HOME%\Anaconda 3\python.exe


### PR DESCRIPTION
Patch:
- Change the wording on the starting page to find python.
- Prevent 'enter' from reseting the startup screen when the user presses enter when the text box is focused.