### PR TITLE
max-height-docstring

### DIFF
--- a/src/browser/jsx/components/ace-pane/ace-pane.css
+++ b/src/browser/jsx/components/ace-pane/ace-pane.css
@@ -8,6 +8,8 @@ div.ace_tooltip {
   padding: 0;
   margin: 0;
   box-shadow: none;
+  max-height: 30%;
+  overflow-x: auto;
 }
 
 div.ace_editor.ace_autocomplete {
@@ -22,4 +24,7 @@ div.ace_editor.ace_autocomplete {
   margin-left: 3px;
   box-shadow: 2px 5px 10px #aaafb3;
   transition: opacity 0.2s;
+  white-space: pre-wrap;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: smaller;
 }

--- a/src/browser/jsx/containers/free-tab-group/free-tab-group.reducer.js
+++ b/src/browser/jsx/containers/free-tab-group/free-tab-group.reducer.js
@@ -45,7 +45,7 @@ function focusTab(state, action) {
     group = state[groupIndex],
     items = group && group.items,
     targetIndex = _.findIndex(items, {id: action.id}),
-    targetItem = targetIndex && items && items[targetIndex];
+    targetItem = items && items[targetIndex];
 
   if (!targetItem || targetItem.hasFocus) {
     return state;
@@ -77,7 +77,7 @@ function moveTab(oldState, action) {
     toGroup = state[_.findIndex(state, {groupId: action.toGroupId})],
     fromGroup = state[_.findIndex(state, {groupId: action.fromGroupId})],
     fromGroupItemIndex = fromGroup && _.findIndex(fromGroup.items, {id: action.id}),
-    removedItems = fromGroup && fromGroup.items.splice(fromGroupItemIndex, 1);
+    removedItems = fromGroup && fromGroupItemIndex !== -1 && fromGroup.items.splice(fromGroupItemIndex, 1);
 
   if (!toGroup) {
     return oldState;

--- a/src/browser/jsx/services/ace-python-completer.js
+++ b/src/browser/jsx/services/ace-python-completer.js
@@ -29,12 +29,6 @@ function handleMatch(context) {
       value = prefix + match.substr(matchPrefix.length);
     }
 
-    // if it's not a filename and there's a '.' in the value, we want
-    // to set the value to just the last item in the list
-    if (value.indexOf('/') == -1 && value.indexOf('.') > -1) {
-      value = value.split('.').slice(value.split('.').length - 1).join('.');
-    }
-
     if (value !== match) {
       meta = match;
     }
@@ -104,6 +98,7 @@ export default {
       callback(null, _.map(result.matches, handleMatch({
         prefix,
         postfix,
+        matchPrefix,
         pos,
         cursorPos,
         result,


### PR DESCRIPTION
Fixes
- docstring content was often too big for the screen, added a scroll and a max-height of 30%
- docstring content assumed monospace font, so added that.