### PR TITLE
fix docstring having no style in ace-pane

### DIFF
--- a/src/browser/jsx/services/ace-python-completer.js
+++ b/src/browser/jsx/services/ace-python-completer.js
@@ -5,7 +5,7 @@ import textUtil from './text-util';
 import AsciiToHtml from 'ansi-to-html';
 
 const convertor = new AsciiToHtml(),
-  className = 'docstring';
+  className = 'rodeo-ace-pane-docstring';
 
 /**
  * @param {Error} error


### PR DESCRIPTION
Fixes https://github.com/yhat/rodeo/issues/468