### PR TITLE
paste-into-terminal-after-shortcut

### DIFF
--- a/src/browser/jsx/containers/free-tab-group/free-tab-group.actions.js
+++ b/src/browser/jsx/containers/free-tab-group/free-tab-group.actions.js
@@ -12,6 +12,7 @@ import documentTerminalViewerActions from '../document-terminal-viewer/document-
 import plotViewerActions from '../plot-viewer/plot-viewer.actions';
 import manageConnectionsSelectors from '../manage-connections-viewer/manage-connections.selectors';
 import pythonLanguage from '../../services/jupyter/python-language';
+import selectionUtil from '../../services/selection-util';
 
 const tabGroupName = 'freeTabGroups',
   pythonTypes = ['python'],
@@ -85,6 +86,7 @@ function focusFirstTabByType(contentType) {
 
             if (focusable) {
               focusable.focus();
+              selectionUtil.selectElement(focusable);
             }
           });
 

--- a/src/browser/jsx/services/selection-util.js
+++ b/src/browser/jsx/services/selection-util.js
@@ -20,9 +20,9 @@ function copy(el) {
   for (let i = 0; i < selection.rangeCount; i++) {
     prevSelection[i] = selection.getRangeAt(i);
   }
-  window.getSelection().removeAllRanges();
+  selection.removeAllRanges();
   range.selectNode(el);
-  window.getSelection().addRange(range);
+  selection.addRange(range);
   document.execCommand('copy');
   _.defer(() => {
     window.getSelection().removeAllRanges();
@@ -32,7 +32,17 @@ function copy(el) {
   });
 }
 
+function selectElement(el) {
+  const range = document.createRange(),
+    selection = window.getSelection();
+
+  selection.removeAllRanges();
+  range.selectNode(el);
+  selection.addRange(range);
+}
+
 export default {
   copy,
-  isSelectionClick
+  isSelectionClick,
+  selectElement
 };


### PR DESCRIPTION
After hitting Cmd+2 (go to terminal), paste will now work.

In other news, Cmd+1 (go to editor), will work as well.