### PR TITLE
updated dependencies with spelling fixes and plugins that block build

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "gulp-util": "^3.0.7",
     "jest": "^15.1.1",
     "json-loader": "^0.5.4",
+    "karma": "^1.3.0",
     "less": "^2.5.1",
     "less-loader": "^2.2.3",
     "merge-stream": "^1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,10 +49,10 @@ module.exports = {
         query: {
           plugins: [
             'lodash',
-            'Transform-runtime',
-            'Transform-react-remove-prop-types',
-            'Transform-react-constant-elements',
-            'Transform-react-inline-elements'
+            'transform-runtime',
+            'transform-react-remove-prop-types',
+            'transform-react-constant-elements',
+            'transform-react-inline-elements'
           ],
           presets: ['react', 'es2015']
         }


### PR DESCRIPTION
hi,
when creating a new build from source, there are some spelling errors that prevent build. "Karma" is also a dependency that prevents the gulp build from running. After this patch, the build works fine.

also fyi, npm run hot-server does not work . localhost:3001 throws an error in the browser "Cannot GET /"