### PR TITLE
Update check.py

### DIFF
--- a/src/node/kernels/python/check.py
+++ b/src/node/kernels/python/check.py
@@ -5,15 +5,16 @@ import os
 import pip
 
 try:
-    import pip
+    import pkg_resources
 except:
-    pip = None
+    pkg_resources = None
 
 def get_packages():
-    if not pip:
+    if not pkg_resources:
         return []
-    installed_packages = pip.get_installed_distributions()
+    installed_packages = [d for d in pkg_resources.working_set]
     packages = [{ "name": i.key, "version": i.version} for i in installed_packages]
+	
     installed_packages_list = sorted(packages, key=lambda x: x['name'])
     return installed_packages_list
 


### PR DESCRIPTION
In pip's version 10.*, there is no function like pip.get_installed_distributions() and from the official documents, it is not recommended for using pip as module. So we need use pkg_resources module to solve this problem.